### PR TITLE
Add:小説投稿にあたってのフォームオブジェクト作成

### DIFF
--- a/app/models/forms/novel_create_form.html.rb
+++ b/app/models/forms/novel_create_form.html.rb
@@ -1,0 +1,32 @@
+class NovelCreateForm
+  include ActiveModel::Model
+
+  attribute :title, :string
+  attribute :genre, :enum
+  attribute :story_length, :enum
+  attribute :plot, :text
+  attribute :image, :string
+
+  attribute :character_role, :string
+  attribute :character, :text
+
+  validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
+  validates :plot, length: { maximum: 5000 }, presence: true
+
+  enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
+                reincarnation: 50, speace_fantasy: 60, horror: 70 }
+  enum story_length: { long: 0, middle: 1, short: 2 }
+
+  validates :character, length: { maximum: 2000 }
+  validates :character_role, length: { maximum:10 }
+
+
+  def save
+    return false unless valid?
+    novel = Novel.new(titile: title, genre: genre, story_length: story_length, plot:, plot, image: image)
+    novel.save
+
+    character = novel.character.build(character_role: character_role, character: character)
+    character.save
+  end
+end

--- a/app/views/novels/_form.html.erb
+++ b/app/views/novels/_form.html.erb
@@ -14,8 +14,8 @@
     <%= f.text_area :plot, class: 'form-control', rows: 20 %>
   </div>
   <div class="form-group">
-    <%= f.lavel :role %>
-    <%= f.text_field :role %>
+    <%= f.lavel :character_role %>
+    <%= f.text_field :character_role %>
   </div>
   <div class="form-group">
     <%= f.lavel :character %>

--- a/app/views/novels/_form.html.erb
+++ b/app/views/novels/_form.html.erb
@@ -1,0 +1,26 @@
+<%= form_with model: @novel_create_form, url: novels_path local: true do |f| %>
+  <div class="form-group">
+    <%= f.label :title %>
+    <%= f.text_field :title, class: 'form-control' %>
+  </div>
+  <div class="form-group">
+    <%= f.label :genre %>
+  </div>
+  <div class="form-group">
+    <%= f.label :story_length %>
+  </div>
+  <div class="form-group">
+    <%= f.label :plot %>
+    <%= f.text_area :plot, class: 'form-control', rows: 20 %>
+  </div>
+  <div class="form-group">
+    <%= f.lavel :role %>
+    <%= f.text_field :role %>
+  </div>
+  <div class="form-group">
+    <%= f.lavel :character %>
+    <%= f.text_field :character %>
+  </div>
+
+  <%= f.submit '投稿する' class: 'btn btn-primary' %>
+<% end %>

--- a/app/views/novels/create.html.erb
+++ b/app/views/novels/create.html.erb
@@ -1,2 +1,0 @@
-<h1>Novels#create</h1>
-<p>Find me in app/views/novels/create.html.erb</p>

--- a/app/views/novels/destroy.html.erb
+++ b/app/views/novels/destroy.html.erb
@@ -1,2 +1,0 @@
-<h1>Novels#destroy</h1>
-<p>Find me in app/views/novels/destroy.html.erb</p>

--- a/app/views/novels/update.html.erb
+++ b/app/views/novels/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Novels#update</h1>
-<p>Find me in app/views/novels/update.html.erb</p>


### PR DESCRIPTION
## 概要

小説投稿には複数のモデルが絡むので、それらの関連付けを行った。
その際にフォームオブジェクトを使用。

## 確認方法

modelsにformsディレクトリを追加、その中にフォーム用ファイルを作成。

## 影響範囲

現状はおそらくない？

## チェックリスト

- [x] カラム名の誤字脱字の確認

## コメント

参考url
https://qiita.com/kumackey/items/b469143f1a0c4902cf4e
https://qiita.com/kamohicokamo/items/d2ea4d71f86d99261b1a

参考ではフォームオブジェクトはapp/formsに作成するのが推奨とあるが、Zeitwerk::NameErrorが起こり、解決法が分からなかったのでmodelsへ移動した。以下、エラー文

```
/Users/mizoguchi-yuusuke/.rbenv/versions/2.6.8/lib/ruby/gems/2.6.0/gems/zeitwerk-2.5.4/lib/zeitwerk/loader.rb:360:in `rescue in block in set_autoloads_in_dir': wrong constant name NovelCreateForm.html inferred by Module from file (Zeitwerk::NameError)

  /Users/mizoguchi-yuusuke/workspace/runteq/plot_form/app/forms/novel_create_form.html.rb

Possible ways to address this:

  * Tell Zeitwerk to ignore this particular file.
  * Tell Zeitwerk to ignore one of its parent directories.
  * Rename the file to comply with the naming conventions.
  * Modify the inflector to handle this case.
```