### PR TITLE
Fix:フォームと重複するバリデーション等を削除

### DIFF
--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,6 +1,3 @@
 class Character < ApplicationRecord
   belongs_to :novel
-
-  validates :character, length: { maximum: 2000 }
-  validates :character_role, length: { maximum:10 }
 end

--- a/app/models/forms/novel_create_form.html.rb
+++ b/app/models/forms/novel_create_form.html.rb
@@ -1,15 +1,18 @@
 class NovelCreateForm
   include ActiveModel::Model
 
+  #novelのカラム
   attribute :title, :string
   attribute :genre, :enum
   attribute :story_length, :enum
   attribute :plot, :text
   attribute :image, :string
 
+  #characterのカラム
   attribute :character_role, :string
   attribute :character, :text
 
+  #novelのバリデーション、enum
   validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
   validates :plot, length: { maximum: 5000 }, presence: true
 
@@ -17,9 +20,9 @@ class NovelCreateForm
                 reincarnation: 50, speace_fantasy: 60, horror: 70 }
   enum story_length: { long: 0, middle: 1, short: 2 }
 
+  #characterのバリデーション
   validates :character, length: { maximum: 2000 }
   validates :character_role, length: { maximum:10 }
-
 
   def save
     return false unless valid?

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -2,12 +2,4 @@ class Novel < ApplicationRecord
   belongs_to :user
   has_many :character, dependent: :destroy
   has_many :review, dependent: :destroy
-
-  validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
-  validates :plot, length: { maximum: 5000 }, presence: true
-
-
-  enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
-                reincarnation: 50, speace_fantasy: 60, horror: 70 }
-  enum story_length: { long: 0, middle: 1, short: 2 }
 end


### PR DESCRIPTION
## 概要

フォームにバリデーションやenumをまとめて記載したので、novelとcharacterから重複する箇所を削除

## 確認方法

novel、character、novel_create_form

## 影響範囲

バリデーションの重複を削除したのみ

## チェックリスト

- [x] 重複している箇所を削除
- [x] コメントでどれが何かを記載

## コメント

novel_create_formの文量が多くなったので、一部(候補はenum)を元の場所に戻すべきか悩む