### PR TITLE
Fix:attributeでtextが使えないので変更

### DIFF
--- a/app/forms/novel_create_form.rb
+++ b/app/forms/novel_create_form.rb
@@ -1,24 +1,8 @@
 class NovelCreateForm
   include ActiveModel::Model
+  include ActiveModel::Validations
 
-  #novelのカラム
-  attribute :title, :string
-  attribute :genre, :enum
-  attribute :story_length, :enum
-  attribute :plot, :text
-  attribute :image, :string
-
-  #characterのカラム
-  attribute :character_role, :string
-  attribute :character, :text
-
-  #novelのバリデーション、enum
-  validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
-  validates :plot, length: { maximum: 5000 }, presence: true
-
-  enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
-                reincarnation: 50, speace_fantasy: 60, horror: 70 }
-  enum story_length: { long: 0, middle: 1, short: 2 }
+  attr_accessor :title, :genre, :story_length, :plot, :image, :character_role, :character
 
   #characterのバリデーション
   validates :character, length: { maximum: 2000 }
@@ -26,10 +10,7 @@ class NovelCreateForm
 
   def save
     return false unless valid?
-    novel = Novel.new(titile: title, genre: genre, story_length: story_length, plot:, plot, image: image)
-    novel.save
-
-    character = novel.character.build(character_role: character_role, character: character)
-    character.save
+    novel = Novel.new(title: title, genre: genre, story_length: story_length, plot: plot, image: image)
+    novel.characters.new(character_role: character_role, character: character)
   end
 end

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -2,4 +2,11 @@ class Novel < ApplicationRecord
   belongs_to :user
   has_many :character, dependent: :destroy
   has_many :review, dependent: :destroy
+
+  validates :title, length: { maximum: 50 }, uniqueness: true, presence: true
+  validates :plot, length: { maximum: 5000 }, presence: true
+
+  enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
+    reincarnation: 50, speace_fantasy: 60, horror: 70 }
+  enum story_length: { long: 0, middle: 1, short: 2 }
 end


### PR DESCRIPTION
## 概要

viewの作成を進めていくと、attributeでtextが使えないことが分かったので、arrt-accessorへ変更。

## 確認方法

novel_create_formの書き方をattr_accessor用へ変更
その際、novelのバリデーションが一部通らなくなったので、novel関連は元へ戻した

## 影響範囲

novelコントローラー及び_form.html.erb

## チェックリスト

- [x] バリデーションの移動
- [x] メソッドの変更

## コメント

attributeの方がスマートな気がするので、textを追加できるならそうしたい。