### PR TITLE
Fix:フォームオブジェクトにuser情報を追加

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -23,7 +23,7 @@ class NovelsController < ApplicationController
   def show
     @novel = Novel.find(params[:id])
     @review = Review.new
-    @reviews = @novel.reviews.includes(:user).order(created_at: :desc)
+    @reviews = @novel.review.includes(:user).order(created_at: :desc)
   end
 
   def edit; end
@@ -50,6 +50,7 @@ class NovelsController < ApplicationController
 
   def novel_params
     params.require(:novel_create_form).permit(
-                  :title, :genre, :story_length, :plot, :image, :character, :character_role, :user_id)
+                  :title, :genre, :story_length, :plot, :image, :character, :character_role).merge(
+                  user_id: current_user.id)
   end
 end

--- a/app/forms/novel_create_form.rb
+++ b/app/forms/novel_create_form.rb
@@ -1,17 +1,26 @@
 class NovelCreateForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
   include ActiveModel::Validations
 
-  attr_accessor :title, :genre, :story_length, :plot, :image, :character_role, :character
+  attribute :title, :string
+  attribute :genre, :integer
+  attribute :story_length, :integer
+  attribute :image, :string
+  attribute :character_role, :string
+  attribute :user_id, :integer
+
+#attributeがtextに対応していない為切り分け。実装されたら変更
+  attr_accessor :plot, :character
 
   #characterのバリデーション
   validates :character, length: { maximum: 2000 }
-  validates :character_role, length: { maximum:10 }
+  validates :character_role, length: { maximum:20 }
 
   def save
     return false unless valid?
-    novel = Novel.new(title: title, genre: genre, story_length: story_length, plot: plot, image: image)
-    novel.save!
+    novel = Novel.new(title: title, genre: genre, story_length: story_length, plot: plot, image: image, user_id: user_id)
+    novel.save
     Character.create(character_role: character_role, character: character)
   end
 end


### PR DESCRIPTION
## 概要

以前のPL(https://github.com/yusuke-mizoguchi/plot_form/pull/45) で解決できなかったエラーを解決。
また、attributeにできるものはattributeへ、できないものはattr_accessorへ切り分け。
また、フォームオブジェクトではcurrent_userは使えないらしい(使っている記事もあったが……？)

## 確認方法

novel_create_formにユーザーidを取得できるようにコードを追加。
novels_controllerのnovel_paramsにユーザーidをマージ


## 影響範囲

小説投稿と編集。

## チェックリスト

- [x] 小説が投稿できることを確認

## コメント

小説投稿時に、character関係が入らない点は次回のPLで修正予定。