### PR TITLE
Add:ユーザー登録にroleを追加

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -12,6 +12,10 @@
           <%= f.email_field :email, class: 'form-control' %>
         </div>
         <div class="form-group">
+            <%= f.label :role %>
+            <%= f.select :role, User.role.keys.map {|t| [t, t]} %>
+          </div>
+        <div class="form-group">
           <%= f.label :password %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>


### PR DESCRIPTION
## 概要

公開範囲指定のために、user登録ページにrole選択を追加

## 確認方法

users/newページ

## 影響範囲

現状はusers/newのみ

## チェックリスト

- [x] roleの設定を確認

## コメント

公開範囲は書き手、読み手、ゲスト。下書き状態も用意する予定。