### PR TITLE
Fix:ジャンル、文量が登録できない不具合を修正

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -30,7 +30,7 @@ class NovelsController < ApplicationController
 
   def update
     if @novel_create_form.update(novel_params)
-      redirect_to novels_path
+      redirect_to novel_path
     else
       render :new
     end

--- a/app/views/novels/new.html.erb
+++ b/app/views/novels/new.html.erb
@@ -9,11 +9,13 @@
           </div>
           <div class="form-group">
             <%= f.label :genre %>
-            <%= f.select :genre, Novel.genres.keys.map {|k| [k, k]} %>
+            <%= f.select :genre, [['ハイファンタジー', 0], ['ローファンタジー', 10], ['文芸', 20] , ['恋愛', 30], ['コメディ', 40],
+                                  ['ミステリー', 50], ['転生・転移', 50], ['SF', 60], ['ホラー', 70]],
+                                  include_blank: 'ジャンルを選択'%>
           </div>
           <div class="form-group">
             <%= f.label :story_length %>
-            <%= f.select :story_length, Novel.story_lengths.keys.map {|t| [t, t]} %>
+            <%= f.select :story_length, [['長編', 0], ['中編', 1], ['短編', 2]], include_blank: '文量を選択' %>
           </div>
           <div class="form-group">
             <%= f.label :plot %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -13,7 +13,7 @@
         </div>
         <div class="form-group">
             <%= f.label :role %>
-            <%= f.select :role, User.role.keys.map {|t| [t, t]} %>
+            <%= f.select :role, User.roles.keys.map {|t| [t, t]} %>
           </div>
         <div class="form-group">
           <%= f.label :password %>


### PR DESCRIPTION
## 概要

質問事項及び、Add:小説一覧ページの作成の不具合を強引に修正。

### 不具合内容

 novel登録時に、enumで登録する箇所がデフォルトから変更できない(form_withが@novel_create_formなのに、Novel.genres.keys.mapとしているから？　ただしNovelCreateFrom.genres〜にするとNoMethodErrorが出る)

## 確認方法

novels/new

## 影響範囲

一応enumに対応する形にしてあるので、他への影響はないはず。

## チェックリスト

- [x] ジャンル、文量をデフォルト以外で登録できることを確認

## コメント

あまりにも強引に解決したせいでnovels/newの可読性とenumの利便性が損なわれているので、質問が溜まってきたら質問する。