### PR TITLE
Add:公開範囲設定

### DIFF
--- a/app/controllers/novels_controller.rb
+++ b/app/controllers/novels_controller.rb
@@ -50,7 +50,7 @@ class NovelsController < ApplicationController
 
   def novel_params
     params.require(:novel_create_form).permit(
-                  :title, :genre, :story_length, :plot, :image, :character_role, :character_text).merge(
+                  :title, :genre, :story_length, :plot, :image, :release, :character_role, :character_text).merge(
                   user_id: current_user.id)
   end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -6,7 +6,7 @@ class UserSessionsController < ApplicationController
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_back_or_to novels_path
+      redirect_to novels_path
     else
       render :new
     end

--- a/app/forms/novel_create_form.rb
+++ b/app/forms/novel_create_form.rb
@@ -7,6 +7,7 @@ class NovelCreateForm
   attribute :genre, :integer
   attribute :story_length, :integer
   attribute :image, :string
+  attribute :release, :string
   attribute :character_role, :string
   attribute :user_id, :integer
   attribute :novel_id, :integer
@@ -20,7 +21,7 @@ class NovelCreateForm
 
   def save
     return false unless valid?
-    novel = Novel.new(title: title, genre: genre, story_length: story_length, plot: plot, image: image, user_id: user_id)
+    novel = Novel.new(title: title, genre: genre, story_length: story_length, plot: plot, image: image, release: release, user_id: user_id)
     novel.save
     character = Character.new(character_role: character_role, character_text: character_text, novel_id: novel.id)
     character.save!

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,5 +1,5 @@
 class Character < ApplicationRecord
   belongs_to :novel
 
-  validates :character_text length: { maximum: 2000 }
+  validates :character_text, length: { maximum: 2000 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,9 +11,8 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :email, uniqueness: true, presence: true
   validates :role, presence: true
-  
 
-  enum role: { reader: 0,  writer: 10, guest: 20}
+  enum role: { reader: 0,  writer: 10}
 
   def own?(object)
     id == object.user_id

--- a/app/views/novels/_novel.html.erb
+++ b/app/views/novels/_novel.html.erb
@@ -1,27 +1,85 @@
-<div class="col-sm-12 col-lg-4 mb-3">
-  <div id="novel-id-<%= novel.id %>">
-    <div class="card">
-      <div class="card-body">
-        <h4 class="card-title">
-          <%= link_to novel.title, novel_path(novel) %>
-        </h4>
-        <ul class="list-inline">
-          <li class="list-inline-item">
-            <%= novel.genre %>
-          </li>
-          <li class="list-inline-item">
-            <%= novel.story_length %>
-          </li>
-          <li class="list-inline-item">
-            <%= icon 'far', 'user' %>
-            <%= novel.user.name %>
-          </li>
-          <li class="list-inline-item">
-            <%= icon 'far', 'calendar' %>
-            <%= l novel.created_at, format: :long %>
-          </li>
-        </ul>
+<% if (novel.release != "3") && current_user&.role == "writer" %>
+  <div class="col-sm-12 col-lg-4 mb-3">
+    <div id="novel-id-<%= novel.id %>">
+      <div class="card">
+        <div class="card-body">
+          <h4 class="card-title">
+            <%= link_to novel.title, novel_path(novel) %>
+          </h4>
+          <ul class="list-inline">
+            <li class="list-inline-item">
+              <%= novel.genre %>
+            </li>
+            <li class="list-inline-item">
+              <%= novel.story_length %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'user' %>
+              <%= novel.user.name %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'calendar' %>
+              <%= l novel.created_at, format: :long %>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% elsif (novel.release == "0" || novel.release == "1") && current_user&.role == "reader" %>
+  <div class="col-sm-12 col-lg-4 mb-3">
+    <div id="novel-id-<%= novel.id %>">
+      <div class="card">
+        <div class="card-body">
+          <h4 class="card-title">
+            <%= link_to novel.title, novel_path(novel) %>
+          </h4>
+          <ul class="list-inline">
+            <li class="list-inline-item">
+              <%= novel.genre %>
+            </li>
+            <li class="list-inline-item">
+              <%= novel.story_length %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'user' %>
+              <%= novel.user.name %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'calendar' %>
+              <%= l novel.created_at, format: :long %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+<% elsif novel.release == "0" %>
+  <div class="col-sm-12 col-lg-4 mb-3">
+    <div id="novel-id-<%= novel.id %>">
+      <div class="card">
+        <div class="card-body">
+          <h4 class="card-title">
+            <%= link_to novel.title, novel_path(novel) %>
+          </h4>
+          <ul class="list-inline">
+            <li class="list-inline-item">
+              <%= novel.genre %>
+            </li>
+            <li class="list-inline-item">
+              <%= novel.story_length %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'user' %>
+              <%= novel.user.name %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'calendar' %>
+              <%= l novel.created_at, format: :long %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/novels/edit.html.erb
+++ b/app/views/novels/edit.html.erb
@@ -9,11 +9,18 @@
           </div>
           <div class="form-group">
             <%= f.label :genre %>
-            <%= f.select :genre, Novel.genres.keys.map {|k| [k, k]} %>
+            <%= f.select :genre, [['ハイファンタジー', 0], ['ローファンタジー', 10], ['文芸', 20] , ['恋愛', 30], ['コメディ', 40],
+                                  ['ミステリー', 50], ['転生・転移', 50], ['SF', 60], ['ホラー', 70]],
+                                  include_blank: 'ジャンルを選択'%>
           </div>
           <div class="form-group">
             <%= f.label :story_length %>
-            <%= f.select :story_length, Novel.story_lengths.keys.map {|t| [t, t]} %>
+            <%= f.select :story_length, [['長編', 0], ['中編', 1], ['短編', 2]], include_blank: '文量を選択' %>
+          </div>
+          <div class="form-group">
+            <%= f.label :release %>
+            <%= f.select :release, [['公開', 0],['読み手まで', 1], ['書き手のみ', 2], ['下書き', 3]],
+                                    include_blank: '公開範囲を選択' %>
           </div>
           <div class="form-group">
             <%= f.label :plot %>

--- a/app/views/novels/new.html.erb
+++ b/app/views/novels/new.html.erb
@@ -18,6 +18,11 @@
             <%= f.select :story_length, [['長編', 0], ['中編', 1], ['短編', 2]], include_blank: '文量を選択' %>
           </div>
           <div class="form-group">
+            <%= f.label :release %>
+            <%= f.select :release, [['公開', 0],['読み手まで', 1], ['書き手のみ', 2], ['下書き', 3]],
+                                    include_blank: '公開範囲を選択' %>
+          </div>
+          <div class="form-group">
             <%= f.label :plot %>
             <%= f.text_area :plot, class: 'form-control', rows: 20 %>
           </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,17 +1,17 @@
 <header>
-  <nav class='navbar navbar-expand-lg navigation navbar-light bg-light container-fluid'>
-    <%= link_to root_path, class: 'navbar-brand' do %>
+  <nav class='navbar navbar-expand-lg navbar-light bg-light container-fluid'>
+    <%= link_to root_path, class: 'navbar-brand float-end' do %>
       <h2>プロットフォーム</h2>
     <% end %>
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
-      <ul class='navbar-nav me-auto list-unstyled float-end'>
+      <ul class='navbar-nav me-auto list-unstyled'>
         <li class="nav-item dropdown">
           <a href="#" class="nav-item btn btn-secondary btn-lg dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             小説メニュー
           </a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-            <%= button_to '小説一覧', novels_path, class: 'dropdown-item' %>
-            <%= button_to '小説投稿', new_novel_path, class: 'dropdown-item' %>
+            <%= link_to '小説一覧', novels_path, class: 'dropdown-item' %>
+            <%= link_to '小説投稿', new_novel_path, class: 'dropdown-item' %>
           </div>
         </li>
         <li class="nav-item dropdown dropdown-slide">

--- a/db/migrate/20220310050831_add_release_to_novels.rb
+++ b/db/migrate/20220310050831_add_release_to_novels.rb
@@ -1,0 +1,5 @@
+class AddReleaseToNovels < ActiveRecord::Migration[6.1]
+  def change
+    add_column :novels, :release, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_04_080442) do
+ActiveRecord::Schema.define(version: 2022_03_10_050831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2022_03_04_080442) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "release", null: false
     t.index ["user_id"], name: "index_novels_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

公開範囲の設定と準備。
enumだとまた登録できないと思ったので、最初からstringで実装。

## その他細かい修正
モデルの記載ミスを修正。
　必要なかったので、userからguestの分類を削除。
ヘッダーのリンクをすべてbuttonにしたが、それだと小説メニューのリンクが機能しなくなったので、ここだけlink_toに戻した。
一部リダイレクトの変更。

## 確認方法

1. カラムを追加したので `bundle exec rails db:migrate` を実行してください
未ログインと読み手と書き手で公開範囲を設定。現状は一覧のみ。

## 影響範囲

小説投稿に公開範囲を追加。
コントローラーやフォームオブジェクトにカラムを追加。

## チェックリスト

- [x] ユーザーの性質ごとに表示される小説が変わることを確認

## コメント

現状urlを直接打ち込むと表示できてしまうので、showにも似た対応が必要。
直打ちを対策するならコントローラーでの対策になると思う。