### PR TITLE
Fix:小説一覧のviewを分割

### DIFF
--- a/app/views/novels/_novel.html.erb
+++ b/app/views/novels/_novel.html.erb
@@ -1,85 +1,8 @@
+
 <% if (novel.release != "3") && current_user&.role == "writer" %>
-  <div class="col-sm-12 col-lg-4 mb-3">
-    <div id="novel-id-<%= novel.id %>">
-      <div class="card">
-        <div class="card-body">
-          <h4 class="card-title">
-            <%= link_to novel.title, novel_path(novel) %>
-          </h4>
-          <ul class="list-inline">
-            <li class="list-inline-item">
-              <%= novel.genre %>
-            </li>
-            <li class="list-inline-item">
-              <%= novel.story_length %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'user' %>
-              <%= novel.user.name %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'calendar' %>
-              <%= l novel.created_at, format: :long %>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render 'novel_date', {novel: novel} %>
 <% elsif (novel.release == "0" || novel.release == "1") && current_user&.role == "reader" %>
-  <div class="col-sm-12 col-lg-4 mb-3">
-    <div id="novel-id-<%= novel.id %>">
-      <div class="card">
-        <div class="card-body">
-          <h4 class="card-title">
-            <%= link_to novel.title, novel_path(novel) %>
-          </h4>
-          <ul class="list-inline">
-            <li class="list-inline-item">
-              <%= novel.genre %>
-            </li>
-            <li class="list-inline-item">
-              <%= novel.story_length %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'user' %>
-              <%= novel.user.name %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'calendar' %>
-              <%= l novel.created_at, format: :long %>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render 'novel_date', {novel: novel} %>
 <% elsif novel.release == "0" %>
-  <div class="col-sm-12 col-lg-4 mb-3">
-    <div id="novel-id-<%= novel.id %>">
-      <div class="card">
-        <div class="card-body">
-          <h4 class="card-title">
-            <%= link_to novel.title, novel_path(novel) %>
-          </h4>
-          <ul class="list-inline">
-            <li class="list-inline-item">
-              <%= novel.genre %>
-            </li>
-            <li class="list-inline-item">
-              <%= novel.story_length %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'user' %>
-              <%= novel.user.name %>
-            </li>
-            <li class="list-inline-item">
-              <%= icon 'far', 'calendar' %>
-              <%= l novel.created_at, format: :long %>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render 'novel_date', {novel: novel} %>
 <% end %>

--- a/app/views/novels/_novel_date.html.erb
+++ b/app/views/novels/_novel_date.html.erb
@@ -1,0 +1,27 @@
+  <div class="col-sm-12 col-lg-4 mb-3">
+    <div id="novel-id-<%= novel.id %>">
+      <div class="card">
+        <div class="card-body">
+          <h4 class="card-title">
+            <%= link_to novel.title, novel_path(novel) %>
+          </h4>
+          <ul class="list-inline">
+            <li class="list-inline-item">
+              <%= novel.genre %>
+            </li>
+            <li class="list-inline-item">
+              <%= novel.story_length %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'user' %>
+              <%= novel.user.name %>
+            </li>
+            <li class="list-inline-item">
+              <%= icon 'far', 'calendar' %>
+              <%= l novel.created_at, format: :long %>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
           </a>
           <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
             <%= link_to 'マイページ', user_path(current_user.id), class: 'dropdown-item' %>
-            <%= link_to 'ログアウト', logout_path, class: 'dropdown-item', method: :delete %>
+            <%= button_to 'ログアウト', logout_path, class: 'dropdown-item', method: :delete %>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## 概要

無駄に長くなっていたnovels/_novelを分割。共通部分を_novel_dateへ移行。

## チェックリスト

- [x] 変更後も公開範囲が機能していることを確認

## コメント

次はshowでの直打ち対策をしたい。