### PR TITLE
Add:ユーザー詳細の一覧にも公開範囲を追加

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,9 @@ class UsersController < ApplicationController
   end
 
   def show
+    @q = Novel.ransack(params[:q])
+    @user_creates = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+
     @user = User.find(params[:id])
     @novel_list = @user.novels.order(created_at: :desc)
     @novels = Kaminari.paginate_array(@novel_list).page(params[:page]).per(4)

--- a/app/forms/novel_create_form.rb
+++ b/app/forms/novel_create_form.rb
@@ -7,7 +7,7 @@ class NovelCreateForm
   attribute :genre, :integer
   attribute :story_length, :integer
   attribute :image, :string
-  attribute :release, :string
+  attribute :release, :integer
   attribute :character_role, :string
   attribute :user_id, :integer
   attribute :novel_id, :integer

--- a/app/models/novel.rb
+++ b/app/models/novel.rb
@@ -9,4 +9,5 @@ class Novel < ApplicationRecord
   enum genre: { high_fantasy: 0, low_fantasy: 10, classic: 20, love: 30, comedy: 40, mystery:50,
     reincarnation: 50, speace_fantasy: 60, horror: 70 }
   enum story_length: { long: 0, middle: 1, short: 2 }
+  enum release: { release: 0, reader: 1, writer: 2, draft: 3 }
 end

--- a/app/views/novels/_novel.html.erb
+++ b/app/views/novels/_novel.html.erb
@@ -1,7 +1,7 @@
-<% if (novel.release != "3") && current_user&.role == "writer" %>
+<% if (novel.release != "draft") && current_user&.role == "writer" %>
   <%= render 'novel_date', {novel: novel} %>
-<% elsif (novel.release == "0" || novel.release == "1") && current_user&.role == "reader" %>
+<% elsif (novel.release == "release" || novel.release == "reader") && current_user&.role == "reader" %>
   <%= render 'novel_date', {novel: novel} %>
-<% elsif novel.release == "0" %>
+<% elsif novel.release == "release" %>
   <%= render 'novel_date', {novel: novel} %>
 <% end %>

--- a/app/views/novels/_novel.html.erb
+++ b/app/views/novels/_novel.html.erb
@@ -1,4 +1,3 @@
-
 <% if (novel.release != "3") && current_user&.role == "writer" %>
   <%= render 'novel_date', {novel: novel} %>
 <% elsif (novel.release == "0" || novel.release == "1") && current_user&.role == "reader" %>

--- a/app/views/users/_show_novels.html.erb
+++ b/app/views/users/_show_novels.html.erb
@@ -1,14 +1,14 @@
-<% @novels.each do |novel| %>
-  <table class="table">
-    <tr>
-      <td><%= link_to novel.user.name, user_path(novel.user.id) %>
-    </tr>
-     <tr>
-      <td><%= link_to novel.title, novel_path(novel.id) %></td>
-    </tr>
-    <tr>
-      <td><%= novel.genre %>
-      <%= novel.story_length %></td>
-    </tr>
-  </table>
-<% end %>
+<div id="user_create-id-<%= user_creates.id %>">
+<table class="table">
+  <tr>
+    <td><%= link_to user_creates.user.name, user_path(user_creates.user.id) %>
+  </tr>
+  <tr>
+    <td><%= link_to user_creates.title, novel_path(user_creates.id) %></td>
+  </tr>
+  <tr>
+    <td><%= user_creates.genre %>
+    <%= user_creates.story_length %></td>
+  </tr>
+</table>
+</div>

--- a/app/views/users/_show_novels.html.erb
+++ b/app/views/users/_show_novels.html.erb
@@ -10,5 +10,10 @@
     <td><%= user_creates.genre %>
     <%= user_creates.story_length %></td>
   </tr>
+    <% if user_creates.user.id == current_user.id %>
+    <tr>
+      <td><%= user_creates.release %></td>
+    </tr>
+  <% end %>
 </table>
 </div>

--- a/app/views/users/_user_creates.html.erb
+++ b/app/views/users/_user_creates.html.erb
@@ -1,0 +1,9 @@
+<% if user_creates.user.id == current_user.id %>
+  <%= render 'users/show_novels', { user_creates: user_creates } %>
+<% elsif (user_creates.release != "3") && current_user&.role == "writer" %>
+  <%= render 'users/show_novels', { user_creates: user_creates } %>
+<% elsif (user_creates.release == "0" || user_creates.release == "1") && current_user&.role == "reader" %>
+  <%= render 'users/show_novels', { user_creates: user_creates } %>
+<% elsif user_creates.release == "0" %>
+  <%= render 'users/show_novels', { user_creates: user_creates } %>
+<% end %>

--- a/app/views/users/_user_creates.html.erb
+++ b/app/views/users/_user_creates.html.erb
@@ -1,9 +1,9 @@
 <% if user_creates.user.id == current_user.id %>
   <%= render 'users/show_novels', { user_creates: user_creates } %>
-<% elsif (user_creates.release != "3") && current_user&.role == "writer" %>
+<% elsif (user_creates.release != "draft") && current_user&.role == "writer" %>
   <%= render 'users/show_novels', { user_creates: user_creates } %>
-<% elsif (user_creates.release == "0" || user_creates.release == "1") && current_user&.role == "reader" %>
+<% elsif (user_creates.release == "release" || user_creates.release == "reader") && current_user&.role == "reader" %>
   <%= render 'users/show_novels', { user_creates: user_creates } %>
-<% elsif user_creates.release == "0" %>
+<% elsif user_creates.release == "release" %>
   <%= render 'users/show_novels', { user_creates: user_creates } %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,7 +25,7 @@
         <input id="TAB-01" type="radio" name="TAB" class="tab-switch" checked="checked" />
         <label class="tab-label" for="TAB-01">投稿した作品</label>
         <div class="tab-content">
-          <%= render 'users/show_novels' %>
+          <%= render partial: 'user_creates', collection: @user_creates %>
           <%= paginate @novels, id: "js-show-novels", remote: true %>
         </div>
         <input id="TAB-02" type="radio" name="TAB" class="tab-switch" checked="checked" />

--- a/db/migrate/20220311144617_change_data_release_to_novel.rb
+++ b/db/migrate/20220311144617_change_data_release_to_novel.rb
@@ -1,0 +1,5 @@
+class ChangeDataReleaseToNovel < ActiveRecord::Migration[6.1]
+  def change
+    change_column :novels, :release, 'integer USING CAST(release AS integer)'
+  end
+end

--- a/db/migrate/20220311145104_change_column_default_to_novels.rb
+++ b/db/migrate/20220311145104_change_column_default_to_novels.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultToNovels < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :novels, :release, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_10_050831) do
+ActiveRecord::Schema.define(version: 2022_03_11_145104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2022_03_10_050831) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "release", null: false
+    t.integer "release", default: 0, null: false
     t.index ["user_id"], name: "index_novels_on_user_id"
   end
 


### PR DESCRIPTION
## 概要

首題の通り。
加えて、投稿者にのみ公開状況を確認できるように設定。その関係でreleaseのカラムをenumで管理するように変更。

## 確認方法

 カラムを変更したので `bundle exec rails db:migrate` を実行してください

## チェックリスト

- [x] 変更後に公開範囲を確認
- [x] 変更後に表示ページの条件を修正

